### PR TITLE
Optional keyword for scaling of Neumann boundary coefficients (FixedGradient method)

### DIFF
--- a/src/pyfvtool/boundary.py
+++ b/src/pyfvtool/boundary.py
@@ -144,7 +144,7 @@ class BoundaryFace:
         Equivalent to 
             a = scale_coeffs; b = 0.0; c = scale_coeffs*gradientvalue
         which defaults to
-            a = 1.0; b = 0.0: c = gradientvalue
+            a = 1.0; b = 0.0; c = gradientvalue
         
         Note that the boundary conditions are always applied in the positive 
         coordinate direction of the corresponding boundary.

--- a/src/pyfvtool/boundary.py
+++ b/src/pyfvtool/boundary.py
@@ -135,13 +135,16 @@ class BoundaryFace:
         self.b = 1.0
         self.c = value
 
-    def fixedGradient(self, gradientvalue):
+    def fixedGradient(self, gradientvalue, scale_coeffs=1.0):
         """
         Set fixed gradient (Neumann) boundary condition
         
         Utility function.
         
-        Equivalent to a = 1.0; b = 0.0; c = gradientvalue
+        Equivalent to 
+            a = scale_coeffs; b = 0.0; c = scale_coeffs*gradientvalue
+        which defaults to
+            a = 1.0; b = 0.0: c = gradientvalue
         
         Note that the boundary conditions are always applied in the positive 
         coordinate direction of the corresponding boundary.
@@ -150,15 +153,23 @@ class BoundaryFace:
         ----------
         value : float or ndarray
             Fixed boundary value(s) to be set.
+        scale_coeffs : float, optional
+            Expert feature. Scales the Neumann BC coefficient by a constant 
+            factor, giving the same gradient, but with different matrix 
+            coefficients in the matrix equation. Can be used to harmonize the 
+            matrix coefficients, for  bringing the boundary coefficients in the
+            same range as the other matrix elements. This helps in robustly
+            solving the sparse matrix equation.
+            The default scale factor is 1.0.
 
         Returns
         -------
         None.
 
         """
-        self.a = 1.0
+        self.a = scale_coeffs
         self.b = 0.0
-        self.c = gradientvalue
+        self.c = scale_coeffs * gradientvalue
         
     def newtonCooling(self, k, h, T_ext, 
                       reverse_direction=False):

--- a/tests/test_BC_utility_methods.py
+++ b/tests/test_BC_utility_methods.py
@@ -97,6 +97,8 @@ def test_fixed_gradient():
     rhocp = 1.0
     alpha = k / rhocp
     
+    #
+    # Calculate 1D profile, with fixedGradient BC on the left
     mesh = pf.Grid1D(Nx, Lx)
     Tcell = pf.CellVariable(mesh, 0.0) 
         
@@ -109,12 +111,35 @@ def test_fixed_gradient():
         assert bc.c[0] == cc, "fixedGradient BC error"
 
     pf.solvePDE(Tcell, [-pf.diffusionTerm(pf.FaceVariable(mesh, alpha))])
-
+       
     # check gradient (will be same over full domain)
     xx, TT = Tcell.plotprofile() # get profile with outer face values
     steadygrad = (TT[-1]-TT[0])/(xx[-1]-xx[0])
-    
     assert np.allclose(-kbc, steadygrad)
+   
+    
+    #
+    # Re-do calculation, but test the scale_coeffs keyword
+    mesh = pf.Grid1D(Nx, Lx)
+    Tcell = pf.CellVariable(mesh, 0.0) 
+        
+    Tcell.BCs.right.fixedValue(T_ext)
+    coeffscale = 2.0
+    Tcell.BCs.left.fixedGradient(-kbc, scale_coeffs=coeffscale)
+    
+    for bc, cc in zip([Tcell.BCs.left], [-kbc]):
+        assert bc.a[0] == coeffscale, "fixedGradient BC error (scaled coefficients)"
+        assert bc.b[0] == 0.0, "fixedGradient BC error (scaled coefficients)"
+        assert bc.c[0] == cc*coeffscale, "fixedGradient BC error (scaled coefficients)"
+
+    pf.solvePDE(Tcell, [-pf.diffusionTerm(pf.FaceVariable(mesh, alpha))])
+    
+    # check gradient (will be same over full domain)
+    xx, TT = Tcell.plotprofile() # get profile with outer face values
+    steadygrad = (TT[-1]-TT[0])/(xx[-1]-xx[0])
+    assert np.allclose(-kbc, steadygrad)
+
+
 
 
 

--- a/tests/test_cell_volumes.py
+++ b/tests/test_cell_volumes.py
@@ -1,0 +1,139 @@
+"""
+Testing cell volume calculation by evaluating the total domain volume
+"""
+
+import numpy as np
+import pyfvtool as pf
+
+
+# For now, bypass the asserts for spherical meshes, simply printing the 
+# erroneous results, without failing.
+BYPASS_SPHERICAL_ASSERTS = True
+
+
+R = 1.0
+Nr = 5   # lower values lead to bigger errors in cell volume calculation 
+
+THETA = 2*np.pi
+Ntheta = 5
+
+Z = 1.0
+Nz = 5
+
+PHI = np.pi
+Nphi = 5
+
+
+
+##
+## CylindricalGrid1D
+
+msh = pf.CylindricalGrid1D(Nr,R)
+u = pf.CellVariable(msh, 1.0)
+
+Van = np.pi * R**2 * 1.0
+mshsum = np.sum(msh.cellvolume)
+uintg = u.domainIntegral()
+
+print(Van, mshsum, uintg)
+
+assert np.allclose(Van, mshsum), "CylindricalGrid1D volume error"
+assert np.allclose(Van, uintg), "CylindricalGrid1D volume error"
+
+
+
+##
+## CylindricalGrid2D
+
+msh = pf.CylindricalGrid2D(Nr, Nz, R, Z)
+u = pf.CellVariable(msh, 1.0)
+
+Van = np.pi * R**2 * Z
+mshsum = np.sum(msh.cellvolume)
+uintg = u.domainIntegral()
+
+print(Van, mshsum, uintg)
+
+assert np.allclose(Van, mshsum), "CylindricalGrid2D volume error"
+assert np.allclose(Van, uintg), "CylindricalGrid2D volume error"
+
+
+
+##
+## PolarGrid2D
+
+msh = pf.PolarGrid2D(Nr, Ntheta, R, THETA)
+u = pf.CellVariable(msh, 1.0)
+
+Van = np.pi * R**2 
+mshsum = np.sum(msh.cellvolume)
+uintg = u.domainIntegral()
+
+print(Van, mshsum, uintg)
+
+assert np.allclose(Van, mshsum), "PolarGrid2D volume error"
+assert np.allclose(Van, uintg), "PolarGrid2D volume error"
+
+
+
+##
+## CylindricalGrid3D
+
+msh = pf.CylindricalGrid3D(Nr, Ntheta, Nz, R, THETA, Z)
+u = pf.CellVariable(msh, 1.0)
+
+Van = np.pi * R**2 * Z
+mshsum = np.sum(msh.cellvolume)
+uintg = u.domainIntegral()
+
+print(Van, mshsum, uintg)
+
+assert np.allclose(Van, mshsum), "CylindricalGrid3D volume error"
+assert np.allclose(Van, uintg), "CylindricalGrid3D volume error"
+
+
+
+##
+## SphericalGrid1D
+
+msh = pf.SphericalGrid1D(Nr, R)
+u = pf.CellVariable(msh, 1.0)
+
+Van = 4/3 * np.pi * R**3
+mshsum = np.sum(msh.cellvolume)
+uintg = u.domainIntegral()
+
+print(Van, mshsum, uintg)
+
+if not BYPASS_SPHERICAL_ASSERTS:
+    assert np.allclose(Van, mshsum), "SphericalGrid1D volume error"
+    assert np.allclose(Van, uintg), "SphericalGrid1D volume error"
+
+
+
+##
+## SphericalGrid3D
+
+# here, theta = 0...pi; phi = 0...2*pi
+THETA = np.pi
+Ntheta = 5
+
+PHI = 2*np.pi
+Nphi = 5
+
+msh = pf.SphericalGrid3D(Nr, Ntheta, Nphi, R, THETA, PHI)
+u = pf.CellVariable(msh, 1.0)
+
+Van = 4/3 * np.pi * R**3
+mshsum = np.sum(msh.cellvolume)
+uintg = u.domainIntegral()
+
+print(Van, mshsum, uintg)
+
+if not BYPASS_SPHERICAL_ASSERTS:
+    assert np.allclose(Van, mshsum), "SphericalGrid3D volume error"
+    assert np.allclose(Van, uintg), "SphericalGrid3D volume error"
+
+
+# remove BYPASS_SPHERICAL_ASSERTS once bug fixed
+assert not BYPASS_SPHERICAL_ASSERTS, "Do not by-pass asserts for spherical meshes"


### PR DESCRIPTION
Closes #61.

Adds the optional `scale_coeffs` keyword argument to the `FixedGradient` boundary condition, together with a specific test of this keyword.

This new keyword highlights the existence of cases where the matrix may need manual conditioning in order to improve robustness in numerical solving the sparse matrix equation.
