### PR TITLE
Set up PyPI publishing via GitHub Actions trusted publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,56 @@
+name: Publish to PyPI
+
+# Publishes to PyPI when a GitHub Release is published.
+# Authentication uses PyPI Trusted Publishing (OIDC) -- no API tokens needed.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:   # allows a manual dry-run of the build job
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade build twine
+          python -m build
+          python -m twine check dist/*
+
+      - name: Upload distributions as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pyfvtool
+
+    permissions:
+      id-token: write   # mandatory for Trusted Publishing
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ vscode/
 _build/
 local/
 
+# Packaging build artifacts
+build/
+dist/
+
 # Git is case-sensitive on some operating systems
 PyFVTool.egg-info/
 pyfvtool.egg-info/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
-    "Development Status :: Beta",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Mathematics"
 ]

--- a/src/pyfvtool/__init__.py
+++ b/src/pyfvtool/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 __author__ = ["Ali A. Eftekhari", "Martinus H. V. Werts"]
 


### PR DESCRIPTION
## Summary

PyFVTool has never been published to PyPI — `https://pypi.org/pypi/pyfvtool/json` returns 404 and the name is unclaimed. This PR adds the release automation needed for a first publication, and fixes a metadata error that would have made the upload fail outright.

## Changes

- **`.github/workflows/publish.yaml`** (new) — builds an sdist and wheel and uploads them to PyPI when a GitHub Release is published. Authentication uses [PyPI trusted publishing](https://docs.pypi.org/trusted-publishers/) (OIDC) through the `pypi` environment, so no API tokens are stored in the repository. `workflow_dispatch` is also wired up, allowing a manual dry-run of the build job without publishing.
- **`pyproject.toml`** — `Development Status :: Beta` is not a valid trove classifier, and PyPI rejects uploads carrying unknown classifiers with an HTTP 400. Corrected to `Development Status :: 4 - Beta`. Note that `twine check` does *not* catch this; it was found by validating against the `trove-classifiers` list.
- **`src/pyfvtool/__init__.py`** — version bumped to `0.5.2`. The existing `v0.5.1` tag points at a commit that predates both the workflow and the classifier fix, so a release cut from it would either not trigger the workflow or fail to upload.
- **`.gitignore`** — ignore the `build/` and `dist/` packaging artifacts.

## Verification

- `uv build` produces `pyfvtool-0.5.2.tar.gz` and `pyfvtool-0.5.2-py3-none-any.whl`
- `twine check` passes on both artifacts
- The wheel installs into a clean Python 3.12 virtualenv, imports, and constructs a `Grid1D` correctly
- Existing test suite: 37 passed. Two modules fail at collection due to missing optional test dependencies (`tqdm`, and MKL for the PARDISO interface); neither is a runtime dependency of the package, so neither affects the release.

## Follow-up after merge

The pending publisher is already configured on PyPI, and the `pypi` environment has been created on this repository. Once merged, the release is cut with:

```bash
git tag -a v0.5.2 -m "PyFVTool 0.5.2"
git push origin v0.5.2
gh release create v0.5.2 --title "PyFVTool 0.5.2" --generate-notes
```

Unrelated cleanup noted for later: `[build-system].requires` lists `numpy`, `scipy`, and `matplotlib`, but this is a pure-Python package with no compiled extensions, so they are not needed at build time. They are already correctly declared as runtime `dependencies`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)