### PR TITLE
Fix left/right periodic boundary conditions in Grid3D. Block use of "radial periodic BCs". Fix top/bottom BCs in 2D.

### DIFF
--- a/src/pyfvtool/advection.py
+++ b/src/pyfvtool/advection.py
@@ -1025,8 +1025,8 @@ def convectionUpwindTerm3D(u: FaceVariable, *args):
     AN[:, -1, :] = AN[:, -1, :]/2.0
     APy[:, -1, :] = APy[:, -1, :]+vn_min[:, -1, :]/(2.0*DYp[:, -1, :])
     # Back boundary:
-    APz[:, :, 0] = APz[:, :, 1]-wb_max[:, :, 1]/(2.0*DZp[:, :, 0])
-    AB[:, :, 0] = AB[:, :, 1]/2.0
+    APz[:, :, 0] = APz[:, :, 0]-wb_max[:, :, 0]/(2.0*DZp[:, :, 0])
+    AB[:, :, 0] = AB[:, :, 0]/2.0
     # Front boundary:
     AF[:, :, -1] = AF[:, :, -1]/2.0
     APz[:, :, -1] = APz[:, :, -1]+wf_min[:, :, -1]/(2.0*DZp[:, :, -1])

--- a/src/pyfvtool/boundary.py
+++ b/src/pyfvtool/boundary.py
@@ -1262,7 +1262,7 @@ def boundaryConditionsTerm3D(BC: BoundaryConditions3D):
         ii[q] = G[i,j,k].ravel()
         jj[q] = G[0,j,k].ravel()
         s[q] = dx_end/dx_1
-        q = q[-1]+int_range[1,Ny*Nz]
+        q = q[-1]+int_range(1,Ny*Nz)
         ii[q] = G[i,j,k].ravel()
         jj[q] = G[1,j,k].ravel()
         s[q] = -dx_end/dx_1

--- a/src/pyfvtool/boundary.py
+++ b/src/pyfvtool/boundary.py
@@ -1058,6 +1058,8 @@ def boundaryConditionsTerm2D(BC: BoundaryConditions2D):
         s[q] = -(BC.left.b/2 - BC.left.a/dx_1)
         BCRHS[G[i,j]] = -BC.left.c
     elif BC.right.periodic or BC.left.periodic:  # periodic boundary condition
+        if (type(BC.domain) is CylindricalGrid2D):
+            raise ValueError("Radial periodic boundary conditions are not physically meaningful.")
         # Right boundary
         i = Nx+1
         j = int_range(1, Ny)
@@ -2088,6 +2090,8 @@ def boundaryConditionsTermSpherical3D(BC: BoundaryConditions3D):
     BCMatrix = csr_array((s[0:q], (ii[0:q], jj[0:q])), 
                          shape=((Nx+2)*(Ny+2)*(Nz+2), (Nx+2)*(Ny+2)*(Nz+2)))
     return BCMatrix, BCRHS
+
+
 
 def boundaryConditionsTerm(BC):
     """

--- a/src/pyfvtool/boundary.py
+++ b/src/pyfvtool/boundary.py
@@ -1677,10 +1677,10 @@ def boundaryConditionsTermCylindrical3D(BC: BoundaryConditions3D):
         s[q] = -(BC.left.b/2 - BC.left.a/dx_1).ravel()
         BCRHS[G[i,j,k].ravel()] = -(BC.left.c).ravel()
     elif BC.right.periodic or BC.left.periodic: # periodic
-        raise ValueError("Radial periodic boundary conditions are not physically relevant in CylindricalGrid3D.")
+        raise ValueError("Radial periodic boundary conditions are not physically meaningful.")
         #
         # Keep this code for future reference, once a physically relevant
-        # case has been identified for radially periodic BCs...
+        # case has been identified for radial periodic BCs...
         #
         # # Right boundary
         # i=Nx+1
@@ -1951,52 +1951,57 @@ def boundaryConditionsTermSpherical3D(BC: BoundaryConditions3D):
         s[q] = -(BC.left.b/2 - BC.left.a/dx_1).ravel()
         BCRHS[G[i,j,k].ravel()] = -(BC.left.c).ravel()
     elif BC.right.periodic or BC.left.periodic: # periodic
-        # for a spherical coordinate system, the left and right boundaries (in the radial direction) cannot be periodic?
-        # or at least I cannot imagine them being periodic
-        # TODO: add a warning here; do the same for all radial boundaries
-        # Right boundary
-        i=Nx+1
-        j=j_ind
-        k=k_ind
-        q = q[-1]+int_range(1,Ny*Nz)
-        ii[q] = G[i,j,k].ravel()
-        jj[q] = G[i,j,k].ravel()
-        s[q] = 1.0
-        q = q[-1]+int_range(1,Ny*Nz)
-        ii[q] = G[i,j,k].ravel()
-        jj[q] = G[i-1,j,k].ravel()
-        s[q] = -1.0
-        q = q[-1]+int_range(1,Ny*Nz)
-        ii[q] = G[i,j,k].ravel()
-        jj[q] = G[0,j,k].ravel()
-        s[q] = dx_end/dx_1
-        q = q[-1]+int_range[1,Ny*Nz]
-        ii[q] = G[i,j,k].ravel()
-        jj[q] = G[1,j,k].ravel()
-        s[q] = -dx_end/dx_1
-        BCRHS[G[i,j,k].ravel()] = 0.0
+        raise ValueError("Radial periodic boundary conditions are not physically meaningful.")
+        #
+        # Keep this code for future reference, once a physically relevant
+        # case has been identified for radial periodic BCs...
+        #
+        # # Right boundary
+        # i=Nx+1
+        # j=j_ind
+        # k=k_ind
+        # q = q[-1]+int_range(1,Ny*Nz)
+        # ii[q] = G[i,j,k].ravel()
+        # jj[q] = G[i,j,k].ravel()
+        # s[q] = 1.0
+        # q = q[-1]+int_range(1,Ny*Nz)
+        # ii[q] = G[i,j,k].ravel()
+        # jj[q] = G[i-1,j,k].ravel()
+        # s[q] = -1.0
+        # q = q[-1]+int_range(1,Ny*Nz)
+        # ii[q] = G[i,j,k].ravel()
+        # jj[q] = G[0,j,k].ravel()
+        # s[q] = dx_end/dx_1
+        # q = q[-1]+int_range(1,Ny*Nz)
+        # ii[q] = G[i,j,k].ravel()
+        # jj[q] = G[1,j,k].ravel()
+        # s[q] = -dx_end/dx_1
+        # BCRHS[G[i,j,k].ravel()] = 0.0
 
-        # Left boundary
-        i = 0
-        j=j_ind
-        k=k_ind
-        q = q[-1]+int_range(1,Ny*Nz)
-        ii[q] = G[i,j,k].ravel()
-        jj[q] = G[i,j,k].ravel()
-        s[q] = 1.0
-        q = q[-1]+int_range(1,Ny*Nz)
-        ii[q] = G[i,j,k].ravel()
-        jj[q] = G[i+1,j,k].ravel()
-        s[q] = 1.0
-        q = q[-1]+int_range(1,Ny*Nz)
-        ii[q] = G[i,j,k].ravel()
-        jj[q] = G[Nx,j,k].ravel()
-        s[q] = -1.0
-        q = q[-1]+int_range(1,Ny*Nz)
-        ii[q] = G[i,j,k].ravel()
-        jj[q] = G[Nx+1,j,k].ravel()
-        s[q] = -1.0
-        BCRHS[G[i,j,k].ravel()] = 0.0
+        # # Left boundary
+        # i = 0
+        # j=j_ind
+        # k=k_ind
+        # q = q[-1]+int_range(1,Ny*Nz)
+        # ii[q] = G[i,j,k].ravel()
+        # jj[q] = G[i,j,k].ravel()
+        # s[q] = 1.0
+        # q = q[-1]+int_range(1,Ny*Nz)
+        # ii[q] = G[i,j,k].ravel()
+        # jj[q] = G[i+1,j,k].ravel()
+        # s[q] = 1.0
+        # q = q[-1]+int_range(1,Ny*Nz)
+        # ii[q] = G[i,j,k].ravel()
+        # jj[q] = G[Nx,j,k].ravel()
+        # s[q] = -1.0
+        # q = q[-1]+int_range(1,Ny*Nz)
+        # ii[q] = G[i,j,k].ravel()
+        # jj[q] = G[Nx+1,j,k].ravel()
+        # s[q] = -1.0
+        # BCRHS[G[i,j,k].ravel()] = 0.0
+        #
+        #
+        #
     if (not BC.front.periodic) and (not BC.back.periodic):
         # Front boundary
         k=Nz+1

--- a/src/pyfvtool/boundary.py
+++ b/src/pyfvtool/boundary.py
@@ -1028,11 +1028,11 @@ def boundaryConditionsTerm2D(BC: BoundaryConditions2D):
         s[q] = 1
         q = q[-1]+i
         ii[q] = G[i,j]
-        jj[q] = G[i,Ny+1] 
+        jj[q] = G[i,Ny] 
         s[q] = -1
         q = q[-1]+i
         ii[q] = G[i,j]  
-        jj[q] = G[i,Ny+2]
+        jj[q] = G[i,Ny+1]
         s[q] = -1
         BCRHS[G[i,j]] = 0
 
@@ -1460,11 +1460,11 @@ def boundaryConditionsTermPolar2D(BC: BoundaryConditions2D):
         s[q] = 1
         q = q[-1]+i
         ii[q] = G[i,j]
-        jj[q] = G[i,Ny+1] 
+        jj[q] = G[i,Ny] 
         s[q] = -1
         q = q[-1]+i
         ii[q] = G[i,j]  
-        jj[q] = G[i,Ny+2]
+        jj[q] = G[i,Ny+1]
         s[q] = -1
         BCRHS[G[i,j]] = 0
 

--- a/src/pyfvtool/boundary.py
+++ b/src/pyfvtool/boundary.py
@@ -1677,49 +1677,57 @@ def boundaryConditionsTermCylindrical3D(BC: BoundaryConditions3D):
         s[q] = -(BC.left.b/2 - BC.left.a/dx_1).ravel()
         BCRHS[G[i,j,k].ravel()] = -(BC.left.c).ravel()
     elif BC.right.periodic or BC.left.periodic: # periodic
-        # Right boundary
-        i=Nx+1
-        j=j_ind
-        k=k_ind
-        q = q[-1]+int_range(1,Ny*Nz)
-        ii[q] = G[i,j,k].ravel()
-        jj[q] = G[i,j,k].ravel()
-        s[q] = 1.0
-        q = q[-1]+int_range(1,Ny*Nz)
-        ii[q] = G[i,j,k].ravel()
-        jj[q] = G[i-1,j,k].ravel()
-        s[q] = -1.0
-        q = q[-1]+int_range(1,Ny*Nz)
-        ii[q] = G[i,j,k].ravel()
-        jj[q] = G[0,j,k].ravel()
-        s[q] = dx_end/dx_1
-        q = q[-1]+int_range[1,Ny*Nz]
-        ii[q] = G[i,j,k].ravel()
-        jj[q] = G[1,j,k].ravel()
-        s[q] = -dx_end/dx_1
-        BCRHS[G[i,j,k].ravel()] = 0.0
+        raise ValueError("Radial periodic boundary conditions are not physically relevant in CylindricalGrid3D.")
+        #
+        # Keep this code for future reference, once a physically relevant
+        # case has been identified for radially periodic BCs...
+        #
+        # # Right boundary
+        # i=Nx+1
+        # j=j_ind
+        # k=k_ind
+        # q = q[-1]+int_range(1,Ny*Nz)
+        # ii[q] = G[i,j,k].ravel()
+        # jj[q] = G[i,j,k].ravel()
+        # s[q] = 1.0
+        # q = q[-1]+int_range(1,Ny*Nz)
+        # ii[q] = G[i,j,k].ravel()
+        # jj[q] = G[i-1,j,k].ravel()
+        # s[q] = -1.0
+        # q = q[-1]+int_range(1,Ny*Nz)
+        # ii[q] = G[i,j,k].ravel()
+        # jj[q] = G[0,j,k].ravel()
+        # s[q] = dx_end/dx_1
+        # q = q[-1]+int_range(1,Ny*Nz)
+        # ii[q] = G[i,j,k].ravel()
+        # jj[q] = G[1,j,k].ravel()
+        # s[q] = -dx_end/dx_1
+        # BCRHS[G[i,j,k].ravel()] = 0.0
 
-        # Left boundary
-        i = 0
-        j=j_ind
-        k=k_ind
-        q = q[-1]+int_range(1,Ny*Nz)
-        ii[q] = G[i,j,k].ravel()
-        jj[q] = G[i,j,k].ravel()
-        s[q] = 1.0
-        q = q[-1]+int_range(1,Ny*Nz)
-        ii[q] = G[i,j,k].ravel()
-        jj[q] = G[i+1,j,k].ravel()
-        s[q] = 1.0
-        q = q[-1]+int_range(1,Ny*Nz)
-        ii[q] = G[i,j,k].ravel()
-        jj[q] = G[Nx,j,k].ravel()
-        s[q] = -1.0
-        q = q[-1]+int_range(1,Ny*Nz)
-        ii[q] = G[i,j,k].ravel()
-        jj[q] = G[Nx+1,j,k].ravel()
-        s[q] = -1.0
-        BCRHS[G[i,j,k].ravel()] = 0.0
+        # # Left boundary
+        # i = 0
+        # j=j_ind
+        # k=k_ind
+        # q = q[-1]+int_range(1,Ny*Nz)
+        # ii[q] = G[i,j,k].ravel()
+        # jj[q] = G[i,j,k].ravel()
+        # s[q] = 1.0
+        # q = q[-1]+int_range(1,Ny*Nz)
+        # ii[q] = G[i,j,k].ravel()
+        # jj[q] = G[i+1,j,k].ravel()
+        # s[q] = 1.0
+        # q = q[-1]+int_range(1,Ny*Nz)
+        # ii[q] = G[i,j,k].ravel()
+        # jj[q] = G[Nx,j,k].ravel()
+        # s[q] = -1.0
+        # q = q[-1]+int_range(1,Ny*Nz)
+        # ii[q] = G[i,j,k].ravel()
+        # jj[q] = G[Nx+1,j,k].ravel()
+        # s[q] = -1.0
+        # BCRHS[G[i,j,k].ravel()] = 0.0
+        #
+        #
+        #
     if (not BC.front.periodic) and (not BC.back.periodic):
         # Front boundary
         k=Nz+1

--- a/src/pyfvtool/boundary.py
+++ b/src/pyfvtool/boundary.py
@@ -6,6 +6,7 @@ from scipy.sparse import csr_array
 
 from .mesh import MeshStructure
 from .mesh import Grid1D, Grid2D, Grid3D
+from .mesh import SphericalGrid1D, CylindricalGrid1D
 from .mesh import CylindricalGrid2D
 from .mesh import PolarGrid2D, CylindricalGrid3D, SphericalGrid3D
 from .utilities import int_range
@@ -897,6 +898,9 @@ def boundaryConditionsTerm1D(BC: BoundaryConditions1D):
         s[q] = -(BC.left.b.item()/2 - BC.left.a.item()/dx_1)
         BCRHS[G[i]] = -BC.left.c.item()
     elif BC.right.periodic or BC.left.periodic:  # periodic boundary condition
+        if (type(BC.domain) is SphericalGrid1D)\
+            or (type(BC.domain) is CylindricalGrid1D):
+                raise ValueError("Radial periodic boundary conditions are not physically meaningful.")
         # Right boundary
         i = Nx+1
         q = q+1

--- a/src/pyfvtool/boundary.py
+++ b/src/pyfvtool/boundary.py
@@ -1488,45 +1488,53 @@ def boundaryConditionsTermPolar2D(BC: BoundaryConditions2D):
         s[q] = -(BC.left.b/2 - BC.left.a/dx_1)
         BCRHS[G[i,j]] = -BC.left.c
     elif BC.right.periodic or BC.left.periodic:  # periodic boundary condition
-        # Right boundary
-        i = Nx+1
-        j = int_range(1, Ny)
-        q = q[-1]+j
-        ii[q] = G[i,j]
-        jj[q] = G[i,j]
-        s[q] = 1
-        q = q[-1]+j
-        ii[q] = G[i,j]
-        jj[q] = G[i-1,j]
-        s[q] = -1
-        q = q[-1]+j
-        ii[q] = G[i,j]
-        jj[q] = G[0,j]
-        s[q] = dx_end/dx_1
-        q = q[-1]+j
-        ii[q] = G[i,j]
-        jj[q] = G[1,j]
-        s[q] = -dx_end/dx_1
-        BCRHS[G[i,j]] = 0
-        # Left boundary
-        i = 0
-        q = q[-1]+j
-        ii[q] = G[i,j]
-        jj[q] = G[i,j]
-        s[q] = 1.0
-        q = q[-1]+j
-        ii[q] = G[i,j]
-        jj[q] = G[i+1,j]
-        s[q] = 1.0
-        q = q[-1]+j
-        ii[q] = G[i,j]
-        jj[q] = G[Nx,j]
-        s[q] = -1.0
-        q = q[-1]+j
-        ii[q] = G[i,j]
-        jj[q] = G[Nx+1,j]
-        s[q] = -1.0
-        BCRHS[G[i,j]] = 0.0
+        raise ValueError("Radial periodic boundary conditions are not physically meaningful.")
+        #
+        # Keep the following code for future reference, once a physically relevant
+        # case has been identified for radial periodic BCs...
+        #
+        # # Right boundary
+        # i = Nx+1
+        # j = int_range(1, Ny)
+        # q = q[-1]+j
+        # ii[q] = G[i,j]
+        # jj[q] = G[i,j]
+        # s[q] = 1
+        # q = q[-1]+j
+        # ii[q] = G[i,j]
+        # jj[q] = G[i-1,j]
+        # s[q] = -1
+        # q = q[-1]+j
+        # ii[q] = G[i,j]
+        # jj[q] = G[0,j]
+        # s[q] = dx_end/dx_1
+        # q = q[-1]+j
+        # ii[q] = G[i,j]
+        # jj[q] = G[1,j]
+        # s[q] = -dx_end/dx_1
+        # BCRHS[G[i,j]] = 0
+        # # Left boundary
+        # i = 0
+        # q = q[-1]+j
+        # ii[q] = G[i,j]
+        # jj[q] = G[i,j]
+        # s[q] = 1.0
+        # q = q[-1]+j
+        # ii[q] = G[i,j]
+        # jj[q] = G[i+1,j]
+        # s[q] = 1.0
+        # q = q[-1]+j
+        # ii[q] = G[i,j]
+        # jj[q] = G[Nx,j]
+        # s[q] = -1.0
+        # q = q[-1]+j
+        # ii[q] = G[i,j]
+        # jj[q] = G[Nx+1,j]
+        # s[q] = -1.0
+        # BCRHS[G[i,j]] = 0.0
+        #
+        #
+        #
     # Build the sparse matrix of the boundary conditions
     q = q[-1] + 1
     BCMatrix = csr_array((s[0:q], (ii[0:q], jj[0:q])), 
@@ -1679,7 +1687,7 @@ def boundaryConditionsTermCylindrical3D(BC: BoundaryConditions3D):
     elif BC.right.periodic or BC.left.periodic: # periodic
         raise ValueError("Radial periodic boundary conditions are not physically meaningful.")
         #
-        # Keep this code for future reference, once a physically relevant
+        # Keep the following code for future reference, once a physically relevant
         # case has been identified for radial periodic BCs...
         #
         # # Right boundary
@@ -1953,7 +1961,7 @@ def boundaryConditionsTermSpherical3D(BC: BoundaryConditions3D):
     elif BC.right.periodic or BC.left.periodic: # periodic
         raise ValueError("Radial periodic boundary conditions are not physically meaningful.")
         #
-        # Keep this code for future reference, once a physically relevant
+        # Keep the following code for future reference, once a physically relevant
         # case has been identified for radial periodic BCs...
         #
         # # Right boundary

--- a/src/pyfvtool/utilities.py
+++ b/src/pyfvtool/utilities.py
@@ -4,11 +4,18 @@ utility functions come here
 
 import numpy as np
 
-def int_range(a:int, b:int) -> np.ndarray:
+
+
+def int_range(a: int, b: int) -> np.ndarray:
     """
-    returns a range of integer values from a to b
+    Returns an array of integers from a to b, inclusive.
+
+    Raises:
+        ValueError: if a > b.
     """
-    return np.linspace(a, b, b-a+1, dtype=int)
+    if (a > b):
+        raise ValueError(f"int_range: expected a <= b, got a={a}, b={b}")
+    return np.arange(a, b + 1)
 
 
 
@@ -27,8 +34,8 @@ def fluxLimiter(flName: str, eps =2e-16):
     available flux limiters are: 'CHARM', 'HCUS', 'HQUICK', 'VanLeer',
     'VanAlbada1', 'VanAlbada2', 'MinMod', 'SUPERBEE', 'Sweby', 'Osher',
     'Koren', 'smart', 'MUSCL', 'QUICK', 'MC', and 'UMIST'.
-    Default limiter is 'SUPERBEE'. See:
-    <http://en.wikipedia.org/wiki/Flux_limiter>
+    Default limiter is 'SUPERBEE'. 
+    See: https://en.wikipedia.org/wiki/Flux_limiter
     
     """
     if flName=="CHARM":

--- a/src/pyfvtool/utilities.py
+++ b/src/pyfvtool/utilities.py
@@ -1,7 +1,7 @@
 """
-utility functions come here
+Utility functions and classes for PyFVTool core code
 """
-
+from collections.abc import Callable
 import numpy as np
 
 
@@ -19,24 +19,32 @@ def int_range(a: int, b: int) -> np.ndarray:
 
 
 
-def fluxLimiter(flName: str, eps =2e-16):
+def fluxLimiter(flName: str, eps: float = 2e-16) -> Callable[[np.ndarray], np.ndarray]:
     """
-    returns a flux limiter function
+    Returns a flux limiter function handle of the user's choice.
 
     Parameters
-    -----
+    ----------
+    flName : str
+        Name of the flux limiter to use. Available options are:
+        'CHARM', 'HCUS', 'HQUICK', 'ospre', 'VanLeer', 'VanAlbada1',
+        'VanAlbada2', 'MinMod', 'SUPERBEE', 'Sweby', 'Osher', 'Koren',
+        'smart', 'MUSCL', 'QUICK', and 'UMIST'.
+        If an unrecognized name is given, 'SUPERBEE' is used instead
+        and a warning is printed.
+    eps : float, optional
+        Small value used to avoid division by zero in limiters with
+        removable singularities (default: 2e-16).
 
-    
+    Returns
+    -------
+    FL : Callable[[np.ndarray], np.ndarray]
+        A function that computes the flux limiter value(s) for a given
+        ratio of successive gradients ``r``.
+
     Notes
     -----
-    This function returns a function handle to a flux limiter of user's
-    choice.
-    available flux limiters are: 'CHARM', 'HCUS', 'HQUICK', 'VanLeer',
-    'VanAlbada1', 'VanAlbada2', 'MinMod', 'SUPERBEE', 'Sweby', 'Osher',
-    'Koren', 'smart', 'MUSCL', 'QUICK', 'MC', and 'UMIST'.
-    Default limiter is 'SUPERBEE'. 
     See: https://en.wikipedia.org/wiki/Flux_limiter
-    
     """
     if flName=="CHARM":
         def FL(r):

--- a/tests/test_BC.py
+++ b/tests/test_BC.py
@@ -1,0 +1,27 @@
+"""
+Simple tests of boundary condition functionality
+
+At present, largely incomplete. We aim for physically meaningful tests, going
+beyond regression testing. Yet, any test is better than no test at all.
+
+The boundary conditions are more rigorously tested for certain meshes in 
+specific test scripts where PyFVTool's numerical result is compared to a known
+existing analytic solution or expected physical behaviour.
+"""
+
+import pyfvtool as pf
+
+
+def test_gaoflow_Grid3D():
+    msh = pf.Grid3D(4, 4, 4, 1.0, 1.0, 1.0)
+    BC = pf.BoundaryConditions(msh)
+    BC.left.periodic = True
+    BC.right.periodic = True
+    BCterm = pf.boundaryConditionsTerm(BC)
+    assert BCterm[0].nnz == 312,\
+        "Unexpected number of stored sparse matrix elements for periodic BCs in Grid3D"
+
+
+if __name__=='__main__':
+    test_gaoflow_Grid3D()
+

--- a/tests/test_BC.py
+++ b/tests/test_BC.py
@@ -8,7 +8,7 @@ The boundary conditions are more rigorously tested for certain meshes in
 specific test scripts where PyFVTool's numerical result is compared to a known
 existing analytic solution or expected physical behaviour.
 """
-
+import numpy as np
 import pyfvtool as pf
 
 
@@ -22,6 +22,23 @@ def test_gaoflow_Grid3D():
         "Unexpected number of stored sparse matrix elements for periodic BCs in Grid3D"
 
 
+def test_gaoflow_CylindricalGrid3D():
+    msh = pf.CylindricalGrid3D(4, 4, 4, 1.0, 2*np.pi, 1.0)
+    BC = pf.BoundaryConditions(msh)
+    BC.left.periodic = True
+    BC.right.periodic = True
+    failed = False
+    try:
+        BCterm = pf.boundaryConditionsTerm(BC)
+    except ValueError:
+        BCterm = None
+        failed = True
+    assert failed,\
+        "Radial periodic boundary conditions should fail for CylindricalGrid3D."
+
+ 
+
+
 if __name__=='__main__':
     test_gaoflow_Grid3D()
-
+    test_gaoflow_CylindricalGrid3D()

--- a/tests/test_BC.py
+++ b/tests/test_BC.py
@@ -70,7 +70,7 @@ def test_gaoflow_PolarGrid2D():
     assert failed,\
         "Radial periodic boundary conditions should raise ValueError for PolarGrid2D."
 
- 
+
 
 def test_gaoflow_CylindricalGrid2D():
     msh = pf.CylindricalGrid2D(4, 4, 1.0, 1.0)
@@ -85,6 +85,38 @@ def test_gaoflow_CylindricalGrid2D():
         failed = True
     assert failed,\
         "Radial periodic boundary conditions should raise ValueError for CylindricalGrid2D."
+        
+
+
+def test_gaoflow_CylindricalGrid1D():
+    msh = pf.CylindricalGrid1D(4, 1.0)
+    BC = pf.BoundaryConditions(msh)
+    BC.left.periodic = True
+    BC.right.periodic = True
+    failed = False
+    try:
+        BCterm = pf.boundaryConditionsTerm(BC)
+    except ValueError:
+        BCterm = None
+        failed = True
+    assert failed,\
+        "Radial periodic boundary conditions should raise ValueError for CylindricalGrid1D."
+      
+
+
+def test_gaoflow_SphericalGrid1D():
+    msh = pf.SphericalGrid1D(4, 1.0)
+    BC = pf.BoundaryConditions(msh)
+    BC.left.periodic = True
+    BC.right.periodic = True
+    failed = False
+    try:
+        BCterm = pf.boundaryConditionsTerm(BC)
+    except ValueError:
+        BCterm = None
+        failed = True
+    assert failed,\
+        "Radial periodic boundary conditions should raise ValueError for SphericalGrid1D."
 
 
 
@@ -94,5 +126,8 @@ if __name__=='__main__':
     test_gaoflow_SphericalGrid3D()
     test_gaoflow_PolarGrid2D()
     test_gaoflow_CylindricalGrid2D()
+    test_gaoflow_CylindricalGrid1D()
+    test_gaoflow_SphericalGrid1D()
+    
     
     

--- a/tests/test_BC.py
+++ b/tests/test_BC.py
@@ -54,10 +54,29 @@ def test_gaoflow_SphericalGrid3D():
     assert failed,\
         "Radial periodic boundary conditions should raise ValueError for SphericalGrid3D."
 
+ 
+
+def test_gaoflow_PolarGrid2D():
+    msh = pf.PolarGrid2D(4, 4, 1.0, 2*np.pi)
+    BC = pf.BoundaryConditions(msh)
+    BC.left.periodic = True
+    BC.right.periodic = True
+    failed = False
+    try:
+        BCterm = pf.boundaryConditionsTerm(BC)
+    except ValueError:
+        BCterm = None
+        failed = True
+    assert failed,\
+        "Radial periodic boundary conditions should raise ValueError for PolarGrid2D."
+
+
 
 
 if __name__=='__main__':
     test_gaoflow_Grid3D()
     test_gaoflow_CylindricalGrid3D()
     test_gaoflow_SphericalGrid3D()
+    test_gaoflow_PolarGrid2D()
+    
     

--- a/tests/test_BC.py
+++ b/tests/test_BC.py
@@ -12,6 +12,7 @@ import numpy as np
 import pyfvtool as pf
 
 
+
 def test_gaoflow_Grid3D():
     msh = pf.Grid3D(4, 4, 4, 1.0, 1.0, 1.0)
     BC = pf.BoundaryConditions(msh)
@@ -20,6 +21,7 @@ def test_gaoflow_Grid3D():
     BCterm = pf.boundaryConditionsTerm(BC)
     assert BCterm[0].nnz == 312,\
         "Unexpected number of stored sparse matrix elements for periodic BCs in Grid3D"
+
 
 
 def test_gaoflow_CylindricalGrid3D():
@@ -34,11 +36,28 @@ def test_gaoflow_CylindricalGrid3D():
         BCterm = None
         failed = True
     assert failed,\
-        "Radial periodic boundary conditions should fail for CylindricalGrid3D."
+        "Radial periodic boundary conditions should raise ValueError for CylindricalGrid3D."
 
  
+
+def test_gaoflow_SphericalGrid3D():
+    msh = pf.SphericalGrid3D(4, 4, 4, 1.0, np.pi, 2*np.pi)
+    BC = pf.BoundaryConditions(msh)
+    BC.left.periodic = True
+    BC.right.periodic = True
+    failed = False
+    try:
+        BCterm = pf.boundaryConditionsTerm(BC)
+    except ValueError:
+        BCterm = None
+        failed = True
+    assert failed,\
+        "Radial periodic boundary conditions should raise ValueError for SphericalGrid3D."
+
 
 
 if __name__=='__main__':
     test_gaoflow_Grid3D()
     test_gaoflow_CylindricalGrid3D()
+    test_gaoflow_SphericalGrid3D()
+    

--- a/tests/test_BC.py
+++ b/tests/test_BC.py
@@ -70,6 +70,21 @@ def test_gaoflow_PolarGrid2D():
     assert failed,\
         "Radial periodic boundary conditions should raise ValueError for PolarGrid2D."
 
+ 
+
+def test_gaoflow_CylindricalGrid2D():
+    msh = pf.CylindricalGrid2D(4, 4, 1.0, 1.0)
+    BC = pf.BoundaryConditions(msh)
+    BC.left.periodic = True
+    BC.right.periodic = True
+    failed = False
+    try:
+        BCterm = pf.boundaryConditionsTerm(BC)
+    except ValueError:
+        BCterm = None
+        failed = True
+    assert failed,\
+        "Radial periodic boundary conditions should raise ValueError for CylindricalGrid2D."
 
 
 
@@ -78,5 +93,6 @@ if __name__=='__main__':
     test_gaoflow_CylindricalGrid3D()
     test_gaoflow_SphericalGrid3D()
     test_gaoflow_PolarGrid2D()
+    test_gaoflow_CylindricalGrid2D()
     
     

--- a/tests/test_BC.py
+++ b/tests/test_BC.py
@@ -20,7 +20,7 @@ def test_gaoflow_Grid3D():
     BC.right.periodic = True
     BCterm = pf.boundaryConditionsTerm(BC)
     assert BCterm[0].nnz == 312,\
-        "Unexpected number of stored sparse matrix elements for periodic BCs in Grid3D"
+        f"Unexpected number of stored sparse matrix elements for periodic BCs in Grid3D: {BCterm[0].nnz}"
 
 
 
@@ -120,6 +120,28 @@ def test_gaoflow_SphericalGrid1D():
 
 
 
+def test_gaoflow_Grid2D_top_bottom():
+    msh = pf.Grid2D(4, 4, 1.0, 1.0)
+    BC = pf.BoundaryConditions(msh)
+    BC.top.periodic = True
+    BC.bottom.periodic = True
+    BCterm = pf.boundaryConditionsTerm(BC)
+    assert BCterm[0].nnz == 52,\
+        f"Unexpected number of stored sparse matrix elements for periodic BCs in Grid2D: {BCterm[0].nnz}"
+
+
+
+def test_gaoflow_PolarGrid2D_top_bottom():
+    msh = pf.PolarGrid2D(4, 4, 1.0, 2*np.pi)
+    BC = pf.BoundaryConditions(msh)
+    BC.top.periodic = True
+    BC.bottom.periodic = True
+    BCterm = pf.boundaryConditionsTerm(BC)
+    assert BCterm[0].nnz == 52,\
+        f"Unexpected number of stored sparse matrix elements for periodic BCs in PolarGrid2D: {BCterm[0].nnz}"
+
+
+
 if __name__=='__main__':
     test_gaoflow_Grid3D()
     test_gaoflow_CylindricalGrid3D()
@@ -128,6 +150,10 @@ if __name__=='__main__':
     test_gaoflow_CylindricalGrid2D()
     test_gaoflow_CylindricalGrid1D()
     test_gaoflow_SphericalGrid1D()
+    test_gaoflow_Grid2D_top_bottom()
+    test_gaoflow_PolarGrid2D_top_bottom()
+    
+    
     
     
     


### PR DESCRIPTION
Fixes #70. 
Fixes #72.

Thanks to @gaoflow for raising these issues.

The crash in #70 was indeed due to a typo.

Furthermore, I agree that "radial periodic boundary conditions" have no physical relevance, and trying to use them should indeed raise a clear exception in PyFVTool. Still, I did keep the corresponding code in a comment for future reference, but I can really not come up with any physically relevant case where such strange BCs would be needed. How would the scalar be conserved in such a scenario? So for now, let's simply close the door to radial periodicity.