### PR TITLE
Fixes for faceLocations()

### DIFF
--- a/src/pyfvtool/face.py
+++ b/src/pyfvtool/face.py
@@ -523,14 +523,15 @@ def faceLocations(m: MeshStructure):
     N = m.dims
     
     if (type(m) is Grid1D)\
-     or (type(m) is CylindricalGrid1D):
+       or (type(m) is CylindricalGrid1D)\
+       or (type(m) is SphericalGrid1D):
         X = FaceVariable(m, 0)
         X._xvalue = m.facecenters._x
         return X
         
     elif (type(m) is Grid2D)\
-       or (type(m) is CylindricalGrid2D)\
-       or (type(m) is PolarGrid2D):
+         or (type(m) is CylindricalGrid2D)\
+         or (type(m) is PolarGrid2D):
         X = FaceVariable(m, 0)
         Y = FaceVariable(m, 0)
         X._xvalue = np.tile(m.facecenters._x[:, np.newaxis], (1, N[1]))
@@ -540,8 +541,8 @@ def faceLocations(m: MeshStructure):
         return X, Y
         
     elif (type(m) is Grid3D)\
-       or (type(m) is CylindricalGrid3D)\
-       or (type(m) is SphericalGrid3D):
+         or (type(m) is CylindricalGrid3D)\
+         or (type(m) is SphericalGrid3D):
         X = FaceVariable(m, 0)
         Y = FaceVariable(m, 0)
         Z = FaceVariable(m, 0)

--- a/src/pyfvtool/face.py
+++ b/src/pyfvtool/face.py
@@ -540,7 +540,8 @@ def faceLocations(m: MeshStructure):
         return X, Y
         
     elif (type(m) is Grid3D)\
-       or (type(m) is CylindricalGrid3D):
+       or (type(m) is CylindricalGrid3D)\
+       or (type(m) is SphericalGrid3D):
         X = FaceVariable(m, 0)
         Y = FaceVariable(m, 0)
         Z = FaceVariable(m, 0)


### PR DESCRIPTION
`SphericalGrid1D` and `SphericalGrid3D` were added to the supported grids in `faceLocations()`. I think we forgot to add them; it is necessary for each grid type to be mentioned explicitly (which seem good practice to me).

Also, I fixed some bugs in the `faceLocations()` routine for 3D grids. The corresponding commits do not show up in this PR, because I clumsily committed these directly to the `FiniteVolumeTranportPhenomena/PyFVtool:main` branch, starting with a really minor edit but then discovering a larger mistake (working side-by-side with Claude). You might want to check them out directly in the commit history.

I will merge this PR directly, since that is easier for me to manage (I'm not good at juggling branches across forks). l leave this as a reminder indicating the changes made.